### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
   workflow_dispatch:
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -21,6 +24,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: github.repository_owner == 'solana-labs'
+    permissions:
+      contents: write
+      packages: write
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1


### PR DESCRIPTION
Potential fix for [https://github.com/Melissa-Forbs/token-list/security/code-scanning/6](https://github.com/Melissa-Forbs/token-list/security/code-scanning/6)

To fix the issue, we will add a `permissions` block to the workflow. At the root level, we will set `contents: read` as the default permission for all jobs. For the `publish` job, we will override the permissions to include `contents: write` and `packages: write`, as these are required for pushing tags and publishing to npm. This ensures that each job has only the permissions it needs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
