### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -10,6 +10,8 @@
 # supported CodeQL languages.
 #
 name: "CodeQL"
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Melissa-Forbs/token-list/security/code-scanning/2](https://github.com/Melissa-Forbs/token-list/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimum permissions required for the workflow to function correctly. Since the workflow primarily involves analyzing code with CodeQL, it likely only needs read access to the repository contents. We will add `permissions: contents: read` at the root level of the workflow to apply this restriction to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
