### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 name: Create Release
+permissions:
+  contents: write
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/Melissa-Forbs/token-list/security/code-scanning/4](https://github.com/Melissa-Forbs/token-list/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow creates a release, it requires `contents: write` permissions. We will set this permission explicitly at the workflow level to ensure that all jobs in the workflow inherit it. This change will restrict the `GITHUB_TOKEN` to only the permissions necessary for the workflow to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
