### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/automerge_new.yml
+++ b/.github/workflows/automerge_new.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "10 * * * *"
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Melissa-Forbs/token-list/security/code-scanning/3](https://github.com/Melissa-Forbs/token-list/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required for the workflow. Based on the operations in the workflow, the following permissions are needed:
- `contents: write` for pushing changes to the repository.
- `pull-requests: write` if the workflow interacts with pull requests (e.g., merging or labeling).
- `actions: read` to allow the workflow to interact with GitHub Actions artifacts.

The `permissions` block will be added at the root level of the workflow file, ensuring it applies to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
